### PR TITLE
use input-event-codes.h if it exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@ retrogame: retrogame.c keyTable.h
 	$(CC) $< -o $@
 	strip $@
 
+ifeq ($(shell [ -r '/usr/include/linux/input-event-codes.h' ] && echo 'X'),X)
+KEYFILE = /usr/include/linux/input-event-codes.h
+else
 KEYFILE = /usr/include/linux/input.h
+endif
 keyTable.h: keyTableGen.sh $(KEYFILE)
 	sh $^ >$@
 


### PR DESCRIPTION
As of current (December 2017) Raspbian, the key codes are in
/usr/include/linux/input-event-codes.h.  This change modifies the
Makefile to use this file if it is present.